### PR TITLE
Make Position::HasInLine really check if the target pos is in line and not if its in range in the cone

### DIFF
--- a/src/server/game/Entities/Object/Position.cpp
+++ b/src/server/game/Entities/Object/Position.cpp
@@ -124,7 +124,8 @@ bool Position::HasInLine(Position const* pos, float objSize, float width) const
 
     width += objSize;
     float angle = GetRelativeAngle(pos);
-    return std::fabs(std::sin(angle)) * GetExactDist2d(pos->GetPositionX(), pos->GetPositionY()) < width;
+    float xAxisDistance = std::fabs(std::cos(angle)) * GetExactDist2d(pos->GetPositionX(), pos->GetPositionY());
+    return G3D::fuzzyLe(xAxisDistance, (width / 2.0f));
 }
 
 std::string Position::ToString() const


### PR DESCRIPTION
Make Position::HasInLine really check if the target pos is in line and not if its in range in the cone